### PR TITLE
fixes handshake ordering issue with ut_metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,10 +323,10 @@ Wire.prototype._onHandshake = function (infoHash, peerId, extensions) {
   this.peerId = peerId
   this.peerExtensions = extensions
 
+  this.emit('handshake', infoHash, peerId, extensions)
   for (var name in this._ext) {
     this._ext[name].onHandshake(infoHash, peerId, extensions)
   }
-  this.emit('handshake', infoHash, peerId, extensions)
 
   /* Peer supports BEP-0010, send extended handshake.
    *


### PR DESCRIPTION
this change allows extensions such as ut_metadata to receive the onHandshake message; without it, they never will because the handshake emit is necessary for upstream dependencies to register extensions.
