### PR TITLE
fix: Emit the wire's peerId on close 

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ class Wire extends stream.Duplex {
     if (this.destroyed) return
     this.destroyed = true
     this._debug('destroy')
-    this.emit('close')
+    this.emit('close', this.peerId)
     this.end()
   }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Now emits the wire's peerId along with the close event

**Which issue (if any) does this pull request address?**
#66 - Emit the wire's peerId on close 

**Is there anything you'd like reviewers to focus on?**
```js
  destroy () {
    if (this.destroyed) return
    this.destroyed = true
    this._debug('destroy')
    this.emit('close', this.peerId) // <----- Emit the wire's peerId
    this.end()
  }
```
