### PR TITLE
fix: return `this` from `destroy` and `end`

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,13 +167,14 @@ class Wire extends stream.Duplex {
     this._debug('destroy')
     this.emit('close')
     this.end()
+    return this
   }
 
   end (...args) {
     this._debug('end')
     this._onUninterested()
     this._onChoke()
-    super.end(...args)
+    return super.end(...args)
   }
 
   /**


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

For consistency with Node readable stream implementation, `destroy()` and `end()` should likely return `this` - https://nodejs.org/api/stream.html#readabledestroyerror

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473
