### PR TITLE
don't push twice for the same message to avoid race conditions

### DIFF
--- a/index.js
+++ b/index.js
@@ -665,8 +665,7 @@ class Wire extends Duplex {
       view.setUint32(5 + (4 * i), numbers[i])
     }
 
-    this._push(buffer)
-    if (data) this._push(data)
+    this._push(concat([buffer,data ?? []]))
   }
 
   _push (data) {


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ x ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This PR changes `Wire._message` such that the entire binary data of a given message is pushed into the buffer at once.  
This is necessary as pushing twice introduces a race condition which would produce malformed message. I saw that in practice and this change has fixed it.

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
`??` is widely available, but I'm not sure what backwards compatibility requirements this project has.