### PR TITLE
chore: upgrade minimum node version to 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - ubuntu-latest
         node:
-          - '18'
+          - '20'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read # for checkout
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -27,10 +35,7 @@ jobs:
             ${{ runner.os }}-npm-
       - name: Install dependencies
         run: npm i
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This pull request updates the Node.js version used in CI and release workflows to 20 and enhances permissions for the release workflow to support publishing and commenting on GitHub releases, issues, and pull requests. It also refines environment variable usage during the release process.

**Workflow Updates**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL15-R15): Updated the Node.js version from 18 to 20 in the CI workflow matrix for improved support and compatibility.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R28): Updated the Node.js version from 18 to 20 in the release workflow.

**Permissions and Security**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R19): Added and scoped permissions for the release workflow, enabling write access to contents, issues, pull requests, and id-token for secure publishing and provenance.

**Environment Variable Management**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-L35): Removed the `NPM_TOKEN` environment variable from the install dependencies and release steps, streamlining the environment setup.