### PR TITLE
chore: Update Node.js engine version requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         os:
           - ubuntu-latest
         node:
-          - '20'
+          - '22'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
       - name: Cache
         uses: actions/cache@v5
         with:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tape": "5.9.0"
   },
   "engines": {
-    "node": ">=12.20.0"
+    "node": ">=22"
   },
   "exports": {
     "import": "./index.js"


### PR DESCRIPTION
This pull request updates the project to use Node.js 22, ensuring compatibility with the latest Node.js features and security updates. The changes affect CI/CD workflows and the `package.json` engine requirements.

**Node.js version upgrades:**

* Updated the Node.js version used in the CI workflow (`.github/workflows/ci.yml`) from 20 to 22 to ensure tests run against the latest Node.js version.
* Updated the Node.js version used in the release workflow (`.github/workflows/release.yml`) from 20 to 22 for consistency in build and deployment environments.
* Changed the `node` engine requirement in `package.json` from `>=12.20.0` to `>=22`, enforcing the use of Node.js 22 or newer for development and deployment.