### PR TITLE
feat: pe-mse

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 *
 !index.js
+!mse.js

--- a/README.md
+++ b/README.md
@@ -200,6 +200,22 @@ wire.on('keep-alive', () => {
 	// peer sent a keep alive - just ignore it
 })
 ```
+
+### protocol encryption (RC4)
+
+Message stream encryption (RC4) is used automatically when both peers support it. The
+cipher can use Node's built-in `crypto.createCipheriv('rc4')` when available (~2-3x faster),
+or falls back to an inline JavaScript implementation.
+
+Check at runtime which path is in use:
+
+```js
+Wire.nativeRC4 // true if native RC4 is available, false if using JS fallback
+```
+
+This is useful for downstream consumers that want to decide whether to enable encryption
+based on performance characteristics. For example, `nativeRC4` is `false` by default on
+Node 17+ (requires `--openssl-legacy-provider`).
 ### fast extension (BEP 6)
 
 This module has built-in support for the

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 /*! bittorrent-protocol. MIT License. WebTorrent LLC <https://webtorrent.io/opensource> */
 import bencode from 'bencode'
 import BitField from 'bitfield'
-import crypto from 'crypto'
 import Debug from 'debug'
-import RC4 from 'rc4'
 import { Duplex } from 'streamx'
-import { hash, concat, equal, hex2arr, arr2hex, text2arr, arr2text, randomBytes } from 'uint8-util'
+import { concat, hex2arr, arr2hex, text2arr, arr2text, randomBytes } from 'uint8-util'
 import throughput from 'throughput'
 import arrayRemove from 'unordered-array-remove'
+import { MessageStreamEncryptor, nativeRC4 } from './mse.js'
 
 const debug = Debug('bittorrent-protocol')
 
@@ -29,16 +28,6 @@ const MESSAGE_PORT = [0x00, 0x00, 0x00, 0x03, 0x09, 0x00, 0x00]
 const MESSAGE_HAVE_ALL = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x0E])
 const MESSAGE_HAVE_NONE = new Uint8Array([0x00, 0x00, 0x00, 0x01, 0x0F])
 
-const DH_PRIME = 'ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f14374fe1356d6d51c245e485b576625e7ec6f44c42e9a63a36210000000000090563'
-const DH_GENERATOR = 2
-const VC = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-const CRYPTO_PROVIDE = new Uint8Array([0x00, 0x00, 0x01, 0x02])
-const CRYPTO_SELECT = new Uint8Array([0x00, 0x00, 0x00, 0x02]) // always try to choose RC4 encryption instead of plaintext
-
-function xor (a, b) {
-  for (let len = a.length; len--;) a[len] ^= b[len]
-  return a
-}
 /**
  * @param {Uint8Array} buffer
  * @param {number} at
@@ -58,6 +47,20 @@ function setUint32 (buffer, at, value) {
   buffer[at + 1] = (value >>> 16) & 0xFF
   buffer[at + 2] = (value >>> 8) & 0xFF
   buffer[at + 3] = value & 0xFF
+}
+
+function indexOfBytes (haystack, needle) {
+  if (needle.length === 0) return 0
+  if (haystack.length < needle.length) return -1
+  const max = haystack.length - needle.length
+  for (let i = 0; i <= max; i++) {
+    let match = true
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) { match = false; break }
+    }
+    if (match) return i
+  }
+  return -1
 }
 
 class Request {
@@ -82,7 +85,8 @@ class HaveAllBitField {
 }
 
 class Wire extends Duplex {
-  constructor (type = null, retries = 0, peEnabled = false) {
+  static nativeRC4 = nativeRC4 // true if Node's crypto supports RC4 (avoids slower JS fallback) Node 17+ (requires `--openssl-legacy-provider`)
+  constructor (type = '', peEnabled = 0) {
     super()
 
     this._debugId = arr2hex(randomBytes(4))
@@ -144,39 +148,39 @@ class Wire extends Duplex {
     this._buffer = [] // incomplete message data
     this._bufferSize = 0 // cached total length of buffers in `this._buffer`
 
-    this._peEnabled = peEnabled
-    if (peEnabled) {
-      this._dh = crypto.createDiffieHellman(DH_PRIME, 'hex', DH_GENERATOR) // crypto object used to generate keys/secret
-      this._myPubKey = this._dh.generateKeys('hex') // my DH public key
-    } else {
-      this._myPubKey = null
-    }
-    this._peerPubKey = null // peer's DH public key
-    this._sharedSecret = null // shared DH secret
-    this._peerCryptoProvide = [] // encryption methods provided by peer; we expect this to always contain 0x02
-    this._cryptoHandshakeDone = false
+    this._peEnabled = peEnabled // 0 = no PE, 1 = PE + plaintext fallback, 2 = PE + RC4 only
+    this._encryptor = null
+    this._infoHash = null
 
     this._cryptoSyncPattern = null // the pattern to search for when resynchronizing after receiving pe1/pe2
+    this._pePending = false // flag set when _parsePe3 callback fires, cleared by setInfoHash
     this._waitMaxBytes = null // the maximum number of bytes resynchronization must occur within
-    this._encryptionMethod = null // 1 for plaintext, 2 for RC4
-    this._encryptGenerator = null // RC4 keystream generator for encryption
-    this._decryptGenerator = null // RC4 keystream generator for decryption
-    this._setGenerators = false // a flag for whether setEncrypt() has successfully completed
-
-    this.once('finish', () => this._onFinish())
 
     this.on('finish', this._onFinish)
     this._debug('type:', this.type)
 
-    if (this.type === 'tcpIncoming' && this._peEnabled) {
-      // If we are not the initiator, we should wait to see if the client begins
-      // with PE/MSE handshake or the standard bittorrent handshake.
-      this._determineHandshakeType()
-    } else if (this.type === 'tcpOutgoing' && this._peEnabled && retries === 0) {
-      this._parsePe2()
+    if (this._peEnabled) {
+      this._encryptor = new MessageStreamEncryptor(this)
+      if (this.type.includes('Incoming')) {
+        this._encryptor.handleIncoming()
+      } else if (this.type.includes('Outgoing')) {
+        this._encryptor.handleOutgoing()
+      }
     } else {
       this._parseHandshake(null)
     }
+  }
+
+  get _peState () {
+    return this._encryptor?.state ?? 'idle'
+  }
+
+  get _encryptionMethod () {
+    return this._encryptor?.encryptionMethod
+  }
+
+  get _cryptoHandshakeDone () {
+    return !!this._encryptor?.cryptoHandshakeDone
   }
 
   /**
@@ -261,65 +265,17 @@ class Wire extends Duplex {
    */
   keepAlive () {
     this._debug('keep-alive')
-    this._push(MESSAGE_KEEP_ALIVE)
+    this._pushCopy(MESSAGE_KEEP_ALIVE)
   }
 
-  sendPe1 () {
-    if (this._peEnabled) {
-      const padALen = Math.floor(Math.random() * 513)
-      const padA = randomBytes(padALen)
-      this._push(concat([hex2arr(this._myPubKey), padA]))
-    }
-  }
-
-  sendPe2 () {
-    const padBLen = Math.floor(Math.random() * 513)
-    const padB = randomBytes(padBLen)
-    this._push(concat([hex2arr(this._myPubKey), padB]))
-  }
-
-  async sendPe3 (infoHash) {
-    await this.setEncrypt(this._sharedSecret, infoHash)
-
-    const hash1Buffer = await hash(hex2arr(this._utfToHex('req1') + this._sharedSecret))
-
-    const hash2Buffer = await hash(hex2arr(this._utfToHex('req2') + infoHash))
-    const hash3Buffer = await hash(hex2arr(this._utfToHex('req3') + this._sharedSecret))
-    const hashesXorBuffer = xor(hash2Buffer, hash3Buffer)
-
-    const padCLen = new DataView(randomBytes(2).buffer).getUint16(0) % 512
-    const padCBuffer = randomBytes(padCLen)
-
-    let vcAndProvideBuffer = new Uint8Array(8 + 4 + 2 + padCLen + 2)
-    vcAndProvideBuffer.set(VC)
-    vcAndProvideBuffer.set(CRYPTO_PROVIDE, 8)
-
-    const view = new DataView(vcAndProvideBuffer.buffer)
-
-    view.setInt16(12, padCLen) // pad C length
-    padCBuffer.copy(vcAndProvideBuffer, 14)
-    view.setInt16(14 + padCLen, 0) // IA length
-    vcAndProvideBuffer = this._encryptHandshake(vcAndProvideBuffer)
-
-    this._push(concat([hash1Buffer, hashesXorBuffer, vcAndProvideBuffer]))
-  }
-
-  async sendPe4 (infoHash) {
-    await this.setEncrypt(this._sharedSecret, infoHash)
-
-    const padDLen = new DataView(randomBytes(2).buffer).getUint16(0) % 512
-    const padDBuffer = randomBytes(padDLen)
-    let vcAndSelectBuffer = new Uint8Array(8 + 4 + 2 + padDLen)
-    const view = new DataView(vcAndSelectBuffer.buffer)
-
-    vcAndSelectBuffer.set(VC)
-    vcAndSelectBuffer.set(CRYPTO_SELECT, 8)
-    view.setInt16(12, padDLen) // lenD?
-    vcAndSelectBuffer.set(padDBuffer, 14)
-    vcAndSelectBuffer = this._encryptHandshake(vcAndSelectBuffer)
-    this._push(vcAndSelectBuffer)
-    this._cryptoHandshakeDone = true
-    this._debug('completed crypto handshake')
+  /**
+   * Start the PE/MSE handshake as initiator.
+   * @param {string} infoHash hex-encoded info hash
+   */
+  startEncryption (infoHash) {
+    if (!this._peEnabled) return
+    this._infoHash = infoHash
+    this._encryptor.startAsInitiator(infoHash)
   }
 
   /**
@@ -407,7 +363,7 @@ class Wire extends Duplex {
     if (this.amChoking) return
     this.amChoking = true
     this._debug('choke')
-    this._push(MESSAGE_CHOKE)
+    this._pushCopy(MESSAGE_CHOKE)
 
     if (this.hasFast) {
       // BEP6: If a peer sends a choke, it MUST reject all requests from the peer to whom the choke
@@ -435,7 +391,7 @@ class Wire extends Duplex {
     if (!this.amChoking) return
     this.amChoking = false
     this._debug('unchoke')
-    this._push(MESSAGE_UNCHOKE)
+    this._pushCopy(MESSAGE_UNCHOKE)
   }
 
   /**
@@ -445,7 +401,7 @@ class Wire extends Duplex {
     if (this.amInterested) return
     this.amInterested = true
     this._debug('interested')
-    this._push(MESSAGE_INTERESTED)
+    this._pushCopy(MESSAGE_INTERESTED)
   }
 
   /**
@@ -455,7 +411,7 @@ class Wire extends Duplex {
     if (!this.amInterested) return
     this.amInterested = false
     this._debug('uninterested')
-    this._push(MESSAGE_UNINTERESTED)
+    this._pushCopy(MESSAGE_UNINTERESTED)
   }
 
   /**
@@ -559,7 +515,7 @@ class Wire extends Duplex {
   haveAll () {
     if (!this.hasFast) throw Error('fast extension is disabled')
     this._debug('have-all')
-    this._push(MESSAGE_HAVE_ALL)
+    this._pushCopy(MESSAGE_HAVE_ALL)
   }
 
   /**
@@ -568,7 +524,7 @@ class Wire extends Duplex {
   haveNone () {
     if (!this.hasFast) throw Error('fast extension is disabled')
     this._debug('have-none')
-    this._push(MESSAGE_HAVE_NONE)
+    this._pushCopy(MESSAGE_HAVE_NONE)
   }
 
   /**
@@ -617,32 +573,13 @@ class Wire extends Duplex {
 
   /**
    * Sets the encryption method for this wire, as per PSE/ME specification
-   *
-   * @param {string} sharedSecret:  A hex-encoded string, which is the shared secret agreed
-   *                                upon from DH key exchange
-   * @param {string} infoHash:  A hex-encoded info hash
-   * @returns boolean, true if encryption setting succeeds, false if it fails.
+   * Called by conn-pool when it resolves the infoHash from a crypto-infohash event.
+   * Initializes the responder's ciphers and resumes pe3 processing.
+   * @param {string} infoHash hex-encoded info hash
    */
-  async setEncrypt (sharedSecret, infoHash) {
-    if (!this.type.startsWith('tcp')) return false
-
-    const outgoing = this.type === 'tcpOutgoing'
-
-    const keyAGenerator = new RC4([...await hash(hex2arr(this._utfToHex('keyA') + sharedSecret + infoHash))])
-    const keyBGenerator = new RC4([...await hash(hex2arr(this._utfToHex('keyB') + sharedSecret + infoHash))])
-
-    this._encryptGenerator = outgoing ? keyAGenerator : keyBGenerator
-    this._decryptGenerator = outgoing ? keyBGenerator : keyAGenerator
-
-    // Discard the first 1024 bytes, as per MSE/PE implementation
-    for (let i = 0; i < 1024; i++) {
-      this._encryptGenerator.randomByte()
-      this._decryptGenerator.randomByte()
-    }
-
-    this._setGenerators = true
-    this.emit('_generators')
-    return true
+  setInfoHash (infoHash) {
+    this._infoHash = infoHash
+    if (this._encryptor) this._encryptor.setInfoHash(infoHash)
   }
 
   /**
@@ -662,11 +599,13 @@ class Wire extends Duplex {
     if (data) this._push(data)
   }
 
+  _pushCopy (data) {
+    return this._push(new Uint8Array(data))
+  }
+
   _push (data) {
     if (this._finished) return
-    if (this._encryptionMethod === 2 && this._cryptoHandshakeDone) {
-      data = this._encrypt(data)
-    }
+    if (this._encryptor) data = this._encryptor.encrypt(data)
     return this.push(data)
   }
 
@@ -677,55 +616,6 @@ class Wire extends Duplex {
   _onKeepAlive () {
     this._debug('got keep-alive')
     this.emit('keep-alive')
-  }
-
-  _onPe1 (pubKeyBuffer) {
-    this._peerPubKey = arr2hex(pubKeyBuffer)
-    this._sharedSecret = this._dh.computeSecret(this._peerPubKey, 'hex', 'hex')
-    this.emit('pe1')
-  }
-
-  _onPe2 (pubKeyBuffer) {
-    this._peerPubKey = arr2hex(pubKeyBuffer)
-    this._sharedSecret = this._dh.computeSecret(this._peerPubKey, 'hex', 'hex')
-    this.emit('pe2')
-  }
-
-  async _onPe3 (hashesXorBuffer) {
-    const hash3 = await hash(hex2arr(this._utfToHex('req3') + this._sharedSecret))
-    const sKeyHash = arr2hex(xor(hash3, hashesXorBuffer))
-    this.emit('pe3', sKeyHash)
-  }
-
-  _onPe3Encrypted (vcBuffer, peerProvideBuffer) {
-    if (!equal(vcBuffer, VC)) {
-      this._debug('Error: verification constant did not match')
-      this.destroy()
-      return
-    }
-
-    for (const provideByte of peerProvideBuffer.values()) {
-      if (provideByte !== 0) {
-        this._peerCryptoProvide.push(provideByte)
-      }
-    }
-    if (this._peerCryptoProvide.includes(2)) {
-      this._encryptionMethod = 2
-    } else {
-      this._debug('Error: RC4 encryption method not provided by peer')
-      this.destroy()
-    }
-  }
-
-  _onPe4 (peerSelectBuffer) {
-    this._encryptionMethod = peerSelectBuffer[3]
-    if (!CRYPTO_PROVIDE.includes(this._encryptionMethod)) {
-      this._debug('Error: peer selected invalid crypto method')
-      this.destroy()
-    }
-    this._cryptoHandshakeDone = true
-    this._debug('crypto handshake done')
-    this.emit('pe4')
   }
 
   _onHandshake (infoHashBuffer, peerIdBuffer, extensions) {
@@ -961,29 +851,34 @@ class Wire extends Duplex {
    * @param  {function} cb
    */
   _write (data, cb) {
-    if (this._encryptionMethod === 2 && this._cryptoHandshakeDone) {
-      data = this._decrypt(data)
-    }
+    if (this._encryptor) data = this._encryptor.decrypt(data)
     this._bufferSize += data.length
     this._buffer.push(data)
     if (this._buffer.length > 1) {
       this._buffer = [concat(this._buffer, this._bufferSize)]
     }
     // now this._buffer is an array containing a single Buffer
+    this._processBuffer()
+    cb(null) // Signal that we're ready for more data
+  }
+
+  _processBuffer () {
     if (this._cryptoSyncPattern) {
-      const index = this._buffer[0].indexOf(this._cryptoSyncPattern)
+      const index = indexOfBytes(this._buffer[0], this._cryptoSyncPattern)
       if (index !== -1) {
         this._buffer[0] = this._buffer[0].slice(index + this._cryptoSyncPattern.length)
         this._bufferSize -= (index + this._cryptoSyncPattern.length)
         this._cryptoSyncPattern = null
-      } else if (this._bufferSize + data.length > this._waitMaxBytes + this._cryptoSyncPattern.length) {
+      } else if (this._bufferSize > this._waitMaxBytes + this._cryptoSyncPattern.length) {
         this._debug('Error: could not resynchronize')
         this.destroy()
         return
       }
+      if (this._cryptoSyncPattern) return
     }
 
-    while (this._bufferSize >= this._parserSize && !this._cryptoSyncPattern) {
+    while (this._bufferSize >= this._parserSize) {
+      if (this._cryptoSyncPattern || this._pePending) break
       if (this._parserSize === 0) {
         this._parser(new Uint8Array())
       } else {
@@ -996,8 +891,6 @@ class Wire extends Duplex {
         this._parser(buffer.subarray(0, this._parserSize))
       }
     }
-
-    cb(null) // Signal that we're ready for more data
   }
 
   _callback (request, err, buffer) {
@@ -1124,92 +1017,6 @@ class Wire extends Duplex {
     }
   }
 
-  _determineHandshakeType () {
-    this._parse(1, pstrLenBuffer => {
-      const pstrlen = pstrLenBuffer[0]
-      if (pstrlen === 19) {
-        this._parse(pstrlen + 48, this._onHandshakeBuffer)
-      } else {
-        this._parsePe1(pstrLenBuffer)
-      }
-    })
-  }
-
-  _parsePe1 (pubKeyPrefix) {
-    this._parse(95, pubKeySuffix => {
-      this._onPe1(concat([pubKeyPrefix, pubKeySuffix]))
-      this._parsePe3()
-    })
-  }
-
-  _parsePe2 () {
-    this._parse(96, async pubKey => {
-      this._onPe2(pubKey)
-      if (!this._setGenerators) {
-        // Wait until generators have been set
-        await new Promise(resolve => this.once('_generators', resolve))
-      }
-      this._parsePe4()
-    })
-  }
-
-  // Handles the unencrypted portion of step 4
-  async _parsePe3 () {
-    const hash1Buffer = await hash(hex2arr(this._utfToHex('req1') + this._sharedSecret))
-    // synchronize on HASH('req1', S)
-    this._parseUntil(hash1Buffer, 512)
-    this._parse(20, async buffer => {
-      this._onPe3(buffer)
-      if (!this._setGenerators) {
-        // Wait until generators have been set
-        await new Promise(resolve => this.once('_generators', resolve))
-      }
-      this._parsePe3Encrypted()
-    })
-  }
-
-  _parsePe3Encrypted () {
-    this._parse(14, buffer => {
-      const vcBuffer = this._decryptHandshake(buffer.slice(0, 8))
-      const peerProvideBuffer = this._decryptHandshake(buffer.slice(8, 12))
-      const padCLen = new DataView(this._decryptHandshake(buffer.slice(12, 14)).buffer).getUint16(0)
-      this._parse(padCLen, padCBuffer => {
-        padCBuffer = this._decryptHandshake(padCBuffer)
-        this._parse(2, iaLenBuf => {
-          const iaLen = new DataView(this._decryptHandshake(iaLenBuf).buffer).getUint16(0)
-          this._parse(iaLen, iaBuffer => {
-            iaBuffer = this._decryptHandshake(iaBuffer)
-            this._onPe3Encrypted(vcBuffer, peerProvideBuffer, padCBuffer, iaBuffer)
-            const pstrlen = iaLen ? iaBuffer[0] : null
-            const protocol = iaLen ? iaBuffer.slice(1, 20) : null
-            if (pstrlen === 19 && arr2text(protocol) === 'BitTorrent protocol') {
-              this._onHandshakeBuffer(iaBuffer.slice(1))
-            } else {
-              this._parseHandshake()
-            }
-          })
-        })
-      })
-    })
-  }
-
-  _parsePe4 () {
-    // synchronize on ENCRYPT(VC).
-    // since we encrypt using bitwise xor, decryption and encryption are the same operation.
-    // calling _decryptHandshake here advances the decrypt generator keystream forward 8 bytes
-    const vcBufferEncrypted = this._decryptHandshake(VC)
-    this._parseUntil(vcBufferEncrypted, 512)
-    this._parse(6, buffer => {
-      const peerSelectBuffer = this._decryptHandshake(buffer.slice(0, 4))
-      const padDLen = new DataView(this._decryptHandshake(buffer.slice(4, 6)).buffer).getUint16(0)
-      this._parse(padDLen, padDBuf => {
-        this._decryptHandshake(padDBuf)
-        this._onPe4(peerSelectBuffer)
-        this._parseHandshake(null)
-      })
-    })
-  }
-
   /**
    * Reads the handshake as specified by the bittorrent wire protocol.
    */
@@ -1274,68 +1081,6 @@ class Wire extends Duplex {
       }
     }
     return null
-  }
-
-  _encryptHandshake (buf) {
-    const crypt = new Uint8Array(buf)
-    if (!this._encryptGenerator) {
-      this._debug('Warning: Encrypting without any generator')
-      return crypt
-    }
-
-    for (let i = 0; i < buf.length; i++) {
-      const keystream = this._encryptGenerator.randomByte()
-      crypt[i] = crypt[i] ^ keystream
-    }
-
-    return crypt
-  }
-
-  _encrypt (buf) {
-    const crypt = new Uint8Array(buf)
-
-    if (!this._encryptGenerator || this._encryptionMethod !== 2) {
-      return crypt
-    }
-    for (let i = 0; i < buf.length; i++) {
-      const keystream = this._encryptGenerator.randomByte()
-      crypt[i] = crypt[i] ^ keystream
-    }
-
-    return crypt
-  }
-
-  _decryptHandshake (buf) {
-    const decrypt = new Uint8Array(buf)
-
-    if (!this._decryptGenerator) {
-      this._debug('Warning: Decrypting without any generator')
-      return decrypt
-    }
-    for (let i = 0; i < buf.length; i++) {
-      const keystream = this._decryptGenerator.randomByte()
-      decrypt[i] = decrypt[i] ^ keystream
-    }
-
-    return decrypt
-  }
-
-  _decrypt (buf) {
-    const decrypt = new Uint8Array(buf)
-
-    if (!this._decryptGenerator || this._encryptionMethod !== 2) {
-      return decrypt
-    }
-    for (let i = 0; i < buf.length; i++) {
-      const keystream = this._decryptGenerator.randomByte()
-      decrypt[i] = decrypt[i] ^ keystream
-    }
-
-    return decrypt
-  }
-
-  _utfToHex (str) {
-    return arr2hex(text2arr(str))
   }
 }
 

--- a/mse.js
+++ b/mse.js
@@ -1,0 +1,427 @@
+import crypto from 'crypto'
+import { concat, hex2arr, arr2hex, arr2text, text2arr, randomBytes, equal } from 'uint8-util'
+
+// true if Node's crypto supports RC4 (avoids slower JS fallback) Node 17+ (requires `--openssl-legacy-provider`)
+export const nativeRC4 = (() => {
+  try {
+    crypto.createCipheriv('rc4', Buffer.alloc(16), '')
+    return true
+  } catch {
+    return false
+  }
+})()
+
+function createRC4Cipher (key) {
+  if (nativeRC4) {
+    const c = crypto.createCipheriv('rc4', key, '')
+    c.update(Buffer.alloc(1024))
+    return buf => c.update(buf)
+  }
+  const s = new Uint8Array(256)
+  for (let i = 0; i < 256; i++) s[i] = i
+  let j = 0
+  for (let i = 0; i < 256; i++) {
+    j = (j + s[i] + key[i % key.length]) & 0xff
+    const tmp = s[i]
+    s[i] = s[j]
+    s[j] = tmp
+  }
+  let ii = 0
+  let jj = 0
+  for (let i = 0; i < 1024; i++) {
+    ii = (ii + 1) & 0xff
+    jj = (jj + s[ii]) & 0xff
+    const tmp = s[ii]
+    s[ii] = s[jj]
+    s[jj] = tmp
+  }
+  return buf => {
+    for (let i = 0; i < buf.length; i++) {
+      ii = (ii + 1) & 0xff
+      jj = (jj + s[ii]) & 0xff
+      const tmp = s[ii]
+      s[ii] = s[jj]
+      s[jj] = tmp
+      buf[i] ^= s[(s[ii] + s[jj]) & 0xff]
+    }
+    return buf
+  }
+}
+
+const DH_PRIME = 'ffffffffffffffffc90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b139b22514a08798e3404ddef9519b3cd3a431b302b0a6df25f14374fe1356d6d51c245e485b576625e7ec6f44c42e9a63a36210000000000090563'
+const DH_GENERATOR = 2
+
+const REQ1_STR = text2arr('req1')
+const REQ2_STR = text2arr('req2')
+const REQ3_STR = text2arr('req3')
+const KEYA_STR = text2arr('keyA')
+const KEYB_STR = text2arr('keyB')
+
+const VC = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+const SYNC_MAX_BYTES = 512
+
+function xor (a, b) {
+  for (let len = a.length; len--;) a[len] ^= b[len]
+  return a
+}
+
+function sha1 (...buffers) {
+  const h = crypto.createHash('sha1')
+  for (const buf of buffers) h.update(buf)
+  return h.digest()
+}
+
+function getUint32 (buffer, at = 0) {
+  return (buffer[at] << 24) | (buffer[at + 1] << 16) | (buffer[at + 2] << 8) | buffer[at + 3]
+}
+
+function getUint16 (buffer, at = 0) {
+  return (buffer[at] << 8) | buffer[at + 1]
+}
+
+export class MessageStreamEncryptor {
+  // PE/MSE handshake flow
+  //
+  //   step 1  A => B    Diffie Hellman Ya, PadA
+  //   step 2  B => A    Diffie Hellman Yb, PadB
+  //   step 3  A => B    HASH('req1',S), HASH('req2',SKEY) XOR HASH('req3',S), ENCRYPT(VC, crypto_provide, len(PadC), PadC, len(IA))
+  //   step 4  B => A    ENCRYPT(VC, crypto_select, len(padD), padD)
+  //   step 5+ A <=> B   ENCRYPT2(Payload Stream)
+  //
+  // Initiator (outgoing, peer A):
+  //   1. startAsInitiator() => generateStepA1() => send step 1 (Ya + PadA), wait for step 2 (Yb + PadB), plaintext handshake, or timeout
+  //   2. handleStepA2() => compute S, init ciphers
+  //   3. generateStepA3() => send step 3, then _handlePe4() resyncs on ENCRYPT(VC)
+  //   4. _onPe4Select/Padding() => decode crypto_select, _finalizeCryptoHandshake()
+  //   5. payload ENCRYPT2() active
+  //
+  // Responder (incoming, peer B):
+  //   1. handleIncoming() => handleStepB1() store Ya
+  //   2. generateStepB2() => send step 2 (Yb + PadB), compute S
+  //   3. _handlePe3() => resync on HASH('req1',S), extract XOR'd SKEY hash => emit 'crypto-infohash'
+  //   4. setInfoHash() => _initializeCiphers('B'), _handlePe3Encrypted(), decodes VC | crypto_provide | len(PadC) | PadC | len(IA) | IA
+  //   5. _onPe3IaLen / _onPe3Ia => optionally process embedded payload (IA)
+  //   6. _advanceEncryption() => generateStepB4() => send step 4, _finalizeCryptoHandshake()
+  //   7. payload ENCRYPT2() active
+  constructor (wireOrKey, skeyHex) {
+    if (typeof wireOrKey === 'string' || wireOrKey === null || wireOrKey === undefined) {
+      this.wire = null
+      this.skeyHex = wireOrKey || null
+    } else {
+      this.wire = wireOrKey
+      this.skeyHex = skeyHex || null
+    }
+    this.state = 'idle' // idle | sentPe1 | gotPe2 | sentPe3 | gotPe3 | done
+    this._dh = null
+    this._isEncrypted = false
+    this.S = null
+    this.encryptCipher = null
+    this.decryptCipher = null
+    this.ya = null
+    this.encryptionMethod = null
+    this.cryptoHandshakeDone = false
+    this._peerCryptoProvide = 0
+  }
+
+  get dh () {
+    if (!this._dh) {
+      this._dh = crypto.createDiffieHellman(DH_PRIME, 'hex', DH_GENERATOR)
+    }
+    return this._dh
+  }
+
+  //
+  // INITIATOR STEPS
+  //
+
+  startAsInitiator (infoHash) {
+    this.skeyHex = infoHash
+    const step1 = this.generateStepA1()
+    this.wire._push(step1)
+    this.state = 'sentPe1'
+    this.wire._debug('PE: sent step 1 (initiator)')
+  }
+
+  generateStepA1 () {
+    const ya = hex2arr(this.dh.generateKeys('hex'))
+    const padA = randomBytes(Math.floor(Math.random() * 513))
+    return concat([ya, padA])
+  }
+
+  handleStepA2 (step2Data) {
+    const yb = step2Data.slice(0, 96)
+    this.S = hex2arr(this.dh.computeSecret(yb, null, 'hex'))
+    this._initializeCiphers('A')
+  }
+
+  generateStepA3 (cryptoProvide = 0x01 | 0x02) {
+    const req1Hash = sha1(REQ1_STR, this.S)
+    const req2Hash = sha1(REQ2_STR, hex2arr(this.skeyHex))
+    const req3Hash = sha1(REQ3_STR, this.S)
+    const xorHash = xor(req2Hash, req3Hash)
+
+    const cryptoProvideBuf = Buffer.alloc(4)
+    cryptoProvideBuf.writeUInt32BE(cryptoProvide, 0)
+
+    const padC = randomBytes(Math.floor(Math.random() * 513))
+    const lenPadC = Buffer.alloc(2)
+    lenPadC.writeUInt16BE(padC.length, 0)
+    const lenIA = Buffer.alloc(2)
+    lenIA.writeUInt16BE(0, 0)
+
+    const plaintext = concat([VC, cryptoProvideBuf, lenPadC, padC, lenIA])
+    const encryptedPart = this.encryptCipher(plaintext)
+
+    return concat([req1Hash, xorHash, encryptedPart])
+  }
+
+  //
+  // RESPONDER STEPS
+  //
+
+  handleStepB1 (step1Data) {
+    this.ya = step1Data.slice(0, 96)
+  }
+
+  generateStepB2 () {
+    const yb = hex2arr(this.dh.generateKeys('hex'))
+    this.S = hex2arr(this.dh.computeSecret(this.ya, null, 'hex'))
+    const padB = randomBytes(Math.floor(Math.random() * 513))
+    return concat([yb, padB])
+  }
+
+  generateStepB4 (cryptoSelect = 0x02) {
+    const cryptoSelectBuf = Buffer.alloc(4)
+    cryptoSelectBuf.writeUInt32BE(cryptoSelect, 0)
+    const padD = randomBytes(Math.floor(Math.random() * 513))
+    const lenPadD = Buffer.alloc(2)
+    lenPadD.writeUInt16BE(padD.length, 0)
+
+    const plaintext = concat([VC, cryptoSelectBuf, lenPadD, padD])
+    return this.encryptCipher(plaintext)
+  }
+
+  getSyncPattern () {
+    return sha1(REQ1_STR, this.S)
+  }
+
+  extractInfoHashFromXor (xorPart) {
+    const req3Hash = sha1(REQ3_STR, this.S)
+    const result = new Uint8Array(xorPart)
+    xor(result, req3Hash)
+    return arr2hex(result)
+  }
+
+  //
+  // PE STATE MACHINE
+  //
+
+  handleIncoming () {
+    this._detectHandshakeOrPe(
+      handshake => this.wire._onHandshakeBuffer(handshake),
+      pubKeyPrefix => {
+        this.wire._parse(76, pubKeySuffix => {
+          this.handleStepB1(concat([pubKeyPrefix, pubKeySuffix]))
+          const step2 = this.generateStepB2()
+          this.state = 'sentPe2'
+          this._handlePe3()
+          this.wire._debug('PE: handled step 1, sent step 2 (responder)')
+          this.wire._push(step2)
+        })
+      }
+    )
+  }
+
+  handleOutgoing () {
+    this._detectHandshakeOrPe(
+      handshake => {
+        this.wire._debug('PE: peer sent plaintext handshake, falling back to no PE')
+        this.state = 'done'
+        this.encryptionMethod = null
+        this.cryptoHandshakeDone = true
+        this.wire.emit('crypto-handshake')
+        this.wire._onHandshakeBuffer(handshake)
+      },
+      pubKeyPrefix => {
+        this.wire._parse(76, pubKeySuffix => {
+          const pubKey = concat([pubKeyPrefix, pubKeySuffix])
+          this.handleStepA2(pubKey)
+          this.state = 'gotPe2'
+          this.wire._debug('PE: handled step 2 (initiator)')
+          this._advanceEncryption()
+        })
+      }
+    )
+  }
+
+  _advanceEncryption () {
+    if (this.state === 'gotPe2' && this.skeyHex) {
+      const provide = this.wire._peEnabled === 2 ? 0x01 | 0x02 : 0x01
+      const step3 = this.generateStepA3(provide)
+      this.state = 'sentPe3'
+      this.wire._debug('PE: sent step 3 (initiator)')
+      this._handlePe4()
+      this.wire._push(step3)
+    }
+    if (this.state === 'gotPe3' && this.skeyHex) {
+      const prefer = this.wire._peEnabled === 1 ? 0x01 : 0x02
+      const fallback = this.wire._peEnabled === 1 ? 0x02 : 0x01
+      const cryptoSelect = this._peerCryptoProvide & prefer
+        ? prefer
+        : this._peerCryptoProvide & fallback
+          ? fallback
+          : 0
+      if (!cryptoSelect) {
+        this.wire._debug('Error: no supported crypto method to select')
+        this.wire.destroy()
+        return
+      }
+      const step4 = this.generateStepB4(cryptoSelect)
+      this.wire._push(step4)
+      this._finalizeCryptoHandshake(cryptoSelect)
+      this.wire._debug('PE: sent step 4 (responder), crypto handshake done (method %s)', cryptoSelect)
+      if (!this.wire.peerId) this.wire._parseHandshake(null)
+    }
+  }
+
+  _finalizeCryptoHandshake (encMethod) {
+    this.state = 'done'
+    this.encryptionMethod = encMethod
+    this.cryptoHandshakeDone = true
+    if (encMethod === 2) this._isEncrypted = true
+    if (this.wire._bufferSize > 0) {
+      const buf = concat(this.wire._buffer, this.wire._bufferSize)
+      this.wire._buffer = [this.decrypt(buf)]
+    }
+    this.wire.emit('crypto-handshake')
+  }
+
+  setInfoHash (infoHash) {
+    this.skeyHex = infoHash.toLowerCase()
+    this._initializeCiphers('B')
+    this._handlePe3Encrypted()
+    this.wire._pePending = false
+    this.wire._processBuffer()
+  }
+
+  //
+  // PARSING HELPERS
+  //
+
+  _detectHandshakeOrPe (onHandshake, onPe) {
+    this.wire._parse(20, first20 => {
+      if (first20[0] === 19 && arr2text(first20.slice(1, 20)) === 'BitTorrent protocol') {
+        this.wire._parse(48, tail => onHandshake(concat([first20.slice(1), tail])))
+      } else {
+        onPe(first20)
+      }
+    })
+  }
+
+  _handlePe3 () {
+    const hash1Buffer = this.getSyncPattern()
+    this.wire._parseUntil(hash1Buffer, SYNC_MAX_BYTES)
+    this.wire._parse(20, buffer => {
+      const infoHashHash = this.extractInfoHashFromXor(buffer)
+      this.state = 'gotPe3'
+      this.wire._debug('PE: handled step 3 XOR hash (responder)')
+      this.wire._pePending = true
+      this.wire.emit('crypto-infohash', infoHashHash)
+    })
+  }
+
+  _handlePe3Encrypted () {
+    this.wire._parse(14, buffer => this._onPe3Header(buffer))
+  }
+
+  _onPe3Header (buffer) {
+    const decHeader = this.decryptCipher(buffer)
+    if (!equal(decHeader.subarray(0, 8), VC)) {
+      this.wire._debug('Error: VC verification failed in pe3')
+      this.wire.destroy()
+      return
+    }
+    this._peerCryptoProvide = getUint32(decHeader, 8)
+    if (this._peerCryptoProvide === 0) {
+      this.wire._debug('Error: no crypto methods provided by peer')
+      this.wire.destroy()
+      return
+    }
+    const padCLen = getUint16(decHeader, 12)
+    this.wire._parse(padCLen, padCBuf => this._onPe3Padding(padCBuf))
+  }
+
+  _onPe3Padding (padCBuf) {
+    this.decryptCipher(padCBuf)
+    this.wire._parse(2, iaLenBuf => this._onPe3IaLen(iaLenBuf))
+  }
+
+  _onPe3IaLen (iaLenBuf) {
+    const decIaLen = this.decryptCipher(iaLenBuf)
+    const iaLen = getUint16(decIaLen, 0)
+    if (iaLen > 0) {
+      this.wire._parse(iaLen, iaBuffer => this._onPe3Ia(iaBuffer))
+    } else {
+      this._advanceEncryption()
+    }
+  }
+
+  _onPe3Ia (iaBuffer) {
+    const ia = this.decryptCipher(iaBuffer)
+    if (ia.length > 0 && ia[0] === 19 && arr2text(ia.slice(1, 20)) === 'BitTorrent protocol') {
+      this.wire._onHandshakeBuffer(ia.slice(1))
+    }
+    this._advanceEncryption()
+  }
+
+  _handlePe4 () {
+    const vcBufferEncrypted = this.decryptCipher(new Uint8Array(VC))
+    this.wire._parseUntil(vcBufferEncrypted, SYNC_MAX_BYTES)
+    this.wire._parse(6, buffer => this._onPe4Select(buffer))
+  }
+
+  _onPe4Select (buffer) {
+    const peerSelect = this.decryptCipher(buffer)
+    const selectedMethod = getUint32(peerSelect, 0)
+    if (selectedMethod !== 1 && selectedMethod !== 2) {
+      this.wire._debug('Error: peer selected unknown crypto method %s', selectedMethod)
+      this.wire.destroy()
+      return
+    }
+    const padDLen = getUint16(peerSelect, 4)
+    this.wire._parse(padDLen, padDBuf => this._onPe4Padding(padDBuf, selectedMethod))
+  }
+
+  _onPe4Padding (padDBuf, selectedMethod) {
+    this.decryptCipher(padDBuf)
+    this._finalizeCryptoHandshake(selectedMethod)
+    this.wire._debug('PE: handled step 4, crypto handshake done (method %s)', selectedMethod)
+    this.wire._parseHandshake(null)
+  }
+
+  //
+  // PAYLOAD CRYPTO
+  //
+
+  encrypt (data) {
+    if (!this._isEncrypted) return data
+    return this.encryptCipher(data)
+  }
+
+  decrypt (data) {
+    if (!this._isEncrypted) return data
+    return this.decryptCipher(data)
+  }
+
+  _initializeCiphers (party) {
+    const keyA = sha1(KEYA_STR, this.S, hex2arr(this.skeyHex))
+    const keyB = sha1(KEYB_STR, this.S, hex2arr(this.skeyHex))
+
+    const encryptKey = party === 'A' ? keyA : keyB
+    const decryptKey = party === 'A' ? keyB : keyA
+
+    this.encryptCipher = createRC4Cipher(encryptKey)
+    this.decryptCipher = createRC4Cipher(decryptKey)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "email": "feross@webtorrent.io",
     "url": "https://webtorrent.io"
   },
+  "browser": {
+    "./mse.js": false
+  },
   "bugs": {
     "url": "https://github.com/webtorrent/bittorrent-protocol/issues"
   },
@@ -15,7 +18,6 @@
     "bencode": "^4.0.0",
     "bitfield": "^4.2.0",
     "debug": "^4.4.3",
-    "rc4": "^0.1.5",
     "streamx": "^2.25.0",
     "throughput": "^1.0.2",
     "uint8-util": "^2.2.6",
@@ -50,7 +52,9 @@
     "url": "git://github.com/webtorrent/bittorrent-protocol.git"
   },
   "scripts": {
-    "test": "standard && tape test/*.js | tap-spec"
+    "test": "standard && tape test/*.js | tap-spec",
+    "perf": "node perf/crypto.js | tap-spec",
+    "perf:native": "node --openssl-legacy-provider perf/crypto.js | tap-spec"
   },
   "funding": [
     {

--- a/perf/crypto.js
+++ b/perf/crypto.js
@@ -1,0 +1,92 @@
+import test from 'tape'
+import Wire from '../index.js'
+import { arr2hex, randomBytes } from 'uint8-util'
+
+function setupWires (pe) {
+  const infoHash = arr2hex(randomBytes(20))
+  const wireA = new Wire('tcpOutgoing', pe)
+  const wireB = new Wire('tcpIncoming', pe)
+  wireA.pipe(wireB).pipe(wireA)
+
+  if (!pe) return { wireA, wireB }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('handshake timeout')), 5000)
+    wireB.once('crypto-infohash', () => wireB.setInfoHash(infoHash))
+    let done = 0
+    const onDone = () => { done++; if (done === 2) { clearTimeout(timeout); resolve({ wireA, wireB }) } }
+    wireA.once('crypto-handshake', onDone)
+    wireB.once('crypto-handshake', onDone)
+    wireA.startEncryption(infoHash)
+  })
+}
+
+// fresh payload per iteration — wire is zero-copy so reusing a single
+// buffer gives unrealistically fast plain numbers
+function benchPieces (wireA, wireB, sizes, iterations) {
+  const results = []
+  for (const size of sizes) {
+    for (let i = 0; i < iterations; i++) wireB.read()
+    const start = process.hrtime.bigint()
+    for (let i = 0; i < iterations; i++) {
+      wireA.piece(0, 0, randomBytes(size))
+      wireB.read()
+    }
+    const ms = Number(process.hrtime.bigint() - start) / 1e6
+    results.push({ size, ms, mbps: size * iterations / ms * 8 / 1000 })
+  }
+  return results
+}
+
+test('piece messages', async t => {
+  const sizes = [1024, 16384, 65536, 262144]
+  const iterations = 500
+
+  const [enc, plain] = await Promise.all([
+    setupWires(2),
+    setupWires(0)
+  ])
+  const encR = benchPieces(enc.wireA, enc.wireB, sizes, iterations)
+  const plainR = benchPieces(plain.wireA, plain.wireB, sizes, iterations)
+  enc.wireA.destroy(); enc.wireB.destroy()
+  plain.wireA.destroy(); plain.wireB.destroy()
+
+  t.plan(sizes.length)
+  for (let i = 0; i < sizes.length; i++) {
+    const pct = ((encR[i].ms / plainR[i].ms) - 1) * 100
+    t.ok(encR[i].ms > 0,
+      `${sizes[i]} B: plain ${plainR[i].mbps.toFixed(0)} Mbps, ` +
+      `enc ${encR[i].mbps.toFixed(0)} Mbps ` +
+      `(+${pct.toFixed(0)}%)`)
+  }
+})
+
+test('small control messages', async t => {
+  const [enc, plain] = await Promise.all([
+    setupWires(2),
+    setupWires(0)
+  ])
+
+  const run = (wireA, wireB, count) => {
+    for (let i = 0; i < count; i++) wireB.read()
+    const start = process.hrtime.bigint()
+    for (let i = 0; i < count; i++) {
+      wireA.keepAlive()
+      wireB.read()
+    }
+    const ms = Number(process.hrtime.bigint() - start) / 1e6
+    return { ms, msgps: count / ms * 1000 }
+  }
+
+  const encR = run(enc.wireA, enc.wireB, 50000)
+  const plainR = run(plain.wireA, plain.wireB, 50000)
+  enc.wireA.destroy(); enc.wireB.destroy()
+  plain.wireA.destroy(); plain.wireB.destroy()
+
+  t.plan(1)
+  const pct = ((encR.ms / plainR.ms) - 1) * 100
+  t.ok(encR.ms > 0,
+    `keepAlive: plain ${plainR.msgps.toFixed(0)} msg/s, ` +
+    `enc ${encR.msgps.toFixed(0)} msg/s ` +
+    `(+${pct.toFixed(2)}%)`)
+})

--- a/test/mse.js
+++ b/test/mse.js
@@ -1,0 +1,513 @@
+import crypto from 'crypto'
+import test from 'tape'
+import Wire from '../index.js'
+import { concat, arr2hex, arr2text, hex2arr, randomBytes, equal, text2arr } from 'uint8-util'
+import { MessageStreamEncryptor } from '../mse.js'
+
+const VC = new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+function btHandshakeBuf (infoHash, peerId) {
+  return concat([text2arr('\u0013BitTorrent protocol'), new Uint8Array(8), hex2arr(infoHash), hex2arr(peerId)])
+}
+
+function piped (levelA, levelB = levelA) {
+  const wireA = new Wire('tcpOutgoing', levelA)
+  const wireB = new Wire('tcpIncoming', levelB)
+  wireA.pipe(wireB).pipe(wireA)
+  return { wireA, wireB }
+}
+
+function startCrypto (wireA, wireB, infoHash) {
+  wireB.once('crypto-infohash', () => wireB.setInfoHash(infoHash))
+  wireA.startEncryption(infoHash)
+}
+
+function onBoth (wireA, wireB, event, fn) {
+  let count = 0
+  const cb = () => { count++; if (count === 2) fn() }
+  wireA.once(event, cb)
+  wireB.once(event, cb)
+}
+
+function hex (len = 20) { return arr2hex(randomBytes(len)) }
+
+function fallbackTest (t, type, level, infoHash, peerId, setup) {
+  const wire = new Wire(type, level)
+  const handshake = btHandshakeBuf(infoHash, peerId)
+  if (setup) setup(wire)
+  wire.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'received peer infoHash')
+    t.equal(gotPI, peerId, 'received peer peerId')
+  })
+  wire._write(handshake, () => { t.pass('handshake processed without error') })
+  return wire
+}
+
+test('PE: wire-to-wire full handshake', t => {
+  t.plan(2)
+
+  const infoHash = hex()
+  const { wireA, wireB } = piped(2)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  wireA.once('crypto-handshake', () => t.pass('initiator crypto handshake done'))
+  wireB.once('crypto-handshake', () => t.pass('responder crypto handshake done'))
+})
+
+test('PE: handshake state transitions', t => {
+  t.plan(8)
+
+  const infoHash = hex()
+  const { wireA, wireB } = piped(2)
+
+  t.equal(wireA._peState, 'idle', 'initiator starts idle')
+  t.equal(wireB._peState, 'idle', 'responder starts idle')
+
+  startCrypto(wireA, wireB, infoHash)
+
+  wireA.once('crypto-handshake', () => {
+    t.equal(wireA._peState, 'done', 'initiator peState done')
+    t.equal(wireA._encryptionMethod, 2, 'initiator using RC4')
+    t.ok(wireA._cryptoHandshakeDone, 'initiator crypto handshake flagged')
+  })
+
+  wireB.once('crypto-handshake', () => {
+    t.equal(wireB._peState, 'done', 'responder peState done')
+    t.equal(wireB._encryptionMethod, 2, 'responder using RC4')
+    t.ok(wireB._cryptoHandshakeDone, 'responder crypto handshake flagged')
+  })
+})
+
+test('PE: wire-to-wire with BT handshake exchange', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(2)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    wireA.handshake(infoHash, peerIdA, { dht: false, fast: true })
+    wireB.handshake(infoHash, peerIdB, { dht: false, fast: true })
+  })
+
+  wireA.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'initiator received correct infoHash')
+    t.equal(gotPI, peerIdB, 'initiator received correct peerId')
+  })
+
+  wireB.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'responder received correct infoHash')
+    t.equal(gotPI, peerIdA, 'responder received correct peerId')
+  })
+})
+
+test('PE: encrypted message exchange', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(2)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    wireA.handshake(infoHash, peerIdA, { dht: false, fast: true })
+    wireB.handshake(infoHash, peerIdB, { dht: false, fast: true })
+  })
+
+  let gotHandshake = 0
+  function onHandshake () {
+    gotHandshake++
+    if (gotHandshake < 2) return
+    wireA.keepAlive()
+    wireB.once('keep-alive', () => t.pass('wireB received keep-alive over encrypted channel'))
+    wireB.keepAlive()
+    wireA.once('keep-alive', () => t.pass('wireA received keep-alive over encrypted channel'))
+  }
+  wireA.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'initiator received correct infoHash')
+    t.equal(gotPI, peerIdB, 'initiator received correct peerId')
+    onHandshake()
+  })
+  wireB.once('handshake', onHandshake)
+})
+
+test('PE: crypto-infohash correct hash', t => {
+  t.plan(3)
+
+  const infoHash = hex()
+  const expectedHashHash = arr2hex(crypto.createHash('sha1').update(concat([text2arr('req2'), hex2arr(infoHash)])).digest())
+  const { wireA, wireB } = piped(2)
+
+  wireB.once('crypto-infohash', ih => {
+    t.equal(ih, expectedHashHash, 'crypto-infohash matches HASH(\'req2\', SKEY)')
+    wireB.setInfoHash(infoHash)
+  })
+
+  wireA.once('crypto-handshake', () => t.pass('handshake completed'))
+  wireB.once('crypto-handshake', () => t.pass('handshake completed'))
+
+  wireA.startEncryption(infoHash)
+})
+
+test('PE: fallback without protocol encryption', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(0)
+
+  wireB.once('handshake', () => wireB.handshake(infoHash, peerIdB))
+  wireA.once('handshake', (ih, pid) => {
+    t.equal(ih, infoHash, 'initiator received handshake')
+    t.equal(pid, peerIdB, 'initiator received correct peerId')
+    t.equal(wireA._peState, 'idle', 'initiator peState stayed idle (no PE)')
+    t.notOk(wireA._encryptor, 'initiator has no encryptor without PE')
+  })
+
+  wireA.handshake(infoHash, peerIdA)
+})
+
+test('PE: plaintext fallback without encryption', t => {
+  t.plan(1)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(0)
+
+  wireB.once('handshake', () => wireB.handshake(infoHash, peerIdB))
+  wireA.once('handshake', () => t.pass('handshake succeeded without PE'))
+
+  wireA.handshake(infoHash, peerIdA)
+})
+
+const MESSAGE_PROTOCOL = text2arr('\u0013BitTorrent protocol')
+
+test('PE: MessageStreamEncryptor key exchange and encrypt/decrypt', t => {
+  const infoHash = hex()
+
+  const initEnc = new MessageStreamEncryptor(infoHash)
+  const respEnc = new MessageStreamEncryptor(infoHash)
+
+  const step1 = initEnc.generateStepA1()
+  t.ok(step1.length >= 96, 'step1 (Ya + padA) >= 96 bytes')
+
+  respEnc.handleStepB1(step1)
+  const step2 = respEnc.generateStepB2()
+  t.ok(step2.length >= 96, 'step2 (Yb + padB) >= 96 bytes')
+  t.ok(respEnc.S, 'responder computed shared secret S')
+  t.ok(respEnc.dh, 'responder has DH keys')
+
+  initEnc.handleStepA2(step2)
+  t.ok(initEnc.S, 'initiator computed shared secret S')
+  t.ok(initEnc.encryptCipher, 'initiator initialized encrypt cipher')
+  t.ok(initEnc.decryptCipher, 'initiator initialized decrypt cipher')
+
+  const step3 = initEnc.generateStepA3()
+  t.ok(step3.length >= 40, 'step3 (req1 + xor + encrypted) >= 40 bytes')
+
+  respEnc.skeyHex = infoHash
+  respEnc._initializeCiphers('B')
+
+  // Manually process step3 using production methods
+  const syncPattern = respEnc.getSyncPattern()
+  const syncIndex = Buffer.from(step3).indexOf(syncPattern)
+  t.notEqual(syncIndex, -1, 'sync pattern found in step3')
+
+  const xorPart = step3.slice(syncIndex + 20, syncIndex + 40)
+  const infoHashHash = respEnc.extractInfoHashFromXor(xorPart)
+  t.equal(typeof infoHashHash, 'string', 'infoHashHash is a hex string')
+  t.equal(infoHashHash.length, 40, 'infoHashHash is 40 hex chars')
+
+  const encryptedRest = step3.slice(syncIndex + 40)
+  const decrypted = respEnc.decryptCipher(encryptedRest)
+  const vc = decrypted.slice(0, 8)
+  t.ok(equal(vc, VC), 'responder VC verification passed')
+
+  const cryptoProvide = (decrypted[8] << 24) | (decrypted[9] << 16) | (decrypted[10] << 8) | decrypted[11]
+  t.ok((cryptoProvide & 0x02) !== 0, 'RC4 crypto method provided')
+  respEnc._isEncrypted = true
+
+  const step4 = respEnc.generateStepB4()
+  t.ok(step4.length >= 14, 'step4 (encrypted VC + select + len(padD) + padD) >= 14 bytes')
+
+  const decStep4 = initEnc.decryptCipher(step4)
+  const vc4 = decStep4.slice(0, 8)
+  t.ok(equal(vc4, VC), 'initiator VC verification passed')
+  const selectedCrypto = (decStep4[8] << 24) | (decStep4[9] << 16) | (decStep4[10] << 8) | decStep4[11]
+  t.equal(selectedCrypto, 0x02, 'initiator got RC4 selection')
+  const padDLen = (decStep4[12] << 8) | decStep4[13]
+  t.equal(typeof padDLen, 'number', 'initiator processed step4, got padD length')
+  initEnc._isEncrypted = true
+
+  const plaintext = new Uint8Array([1, 2, 3, 4, 5])
+  const encrypted = respEnc.encrypt(new Uint8Array(plaintext))
+  t.notOk(equal(encrypted, plaintext), 'encrypted data differs from plaintext')
+  const decrypted2 = initEnc.decrypt(encrypted)
+  t.ok(equal(decrypted2, plaintext), 'decrypted data matches original plaintext')
+
+  t.end()
+})
+
+test('PE: handshake embedded in IA payload', t => {
+  const infoHash = hex()
+  const peerId = hex()
+  const infoHashBytes = hex2arr(infoHash)
+  const peerIdBytes = hex2arr(peerId)
+
+  const initEnc = new MessageStreamEncryptor(infoHash)
+  const respEnc = new MessageStreamEncryptor(infoHash)
+
+  const step1 = initEnc.generateStepA1()
+  respEnc.handleStepB1(step1)
+  const step2 = respEnc.generateStepB2()
+  initEnc.handleStepA2(step2)
+
+  const btHandshake = concat([
+    MESSAGE_PROTOCOL,
+    new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    infoHashBytes,
+    peerIdBytes
+  ])
+
+  // Build step3 manually with embedded IA (production never embeds IA,
+  // but the responder must handle it when received)
+  const req1Hash = crypto.createHash('sha1').update(concat([text2arr('req1'), initEnc.S])).digest()
+  const req2Hash = crypto.createHash('sha1').update(concat([text2arr('req2'), hex2arr(infoHash)])).digest()
+  const req3Hash = crypto.createHash('sha1').update(concat([text2arr('req3'), initEnc.S])).digest()
+  const xorHash = new Uint8Array(20)
+  for (let i = 0; i < 20; i++) xorHash[i] = req2Hash[i] ^ req3Hash[i]
+
+  const cryptoProvideBuf = new Uint8Array([0x00, 0x00, 0x00, 0x03]) // RC4 + plaintext
+  const padC = randomBytes(Math.floor(Math.random() * 513))
+  const lenPadC = new Uint8Array([(padC.length >> 8) & 0xff, padC.length & 0xff])
+  const lenIA = new Uint8Array([(btHandshake.length >> 8) & 0xff, btHandshake.length & 0xff])
+  const plaintext = concat([VC, cryptoProvideBuf, lenPadC, padC, lenIA])
+  const encryptedPart = initEnc.encryptCipher(plaintext)
+  const encryptedIA = initEnc.encryptCipher(btHandshake)
+  const step3 = concat([req1Hash, xorHash, encryptedPart, encryptedIA])
+
+  respEnc.skeyHex = infoHash
+  respEnc._initializeCiphers('B')
+
+  // Process step3 using production methods
+  const syncPattern = respEnc.getSyncPattern()
+  const syncIndex = Buffer.from(step3).indexOf(syncPattern)
+  t.notEqual(syncIndex, -1, 'sync pattern found in step3')
+
+  const encryptedRest = step3.slice(syncIndex + 40)
+  const decrypted = respEnc.decryptCipher(encryptedRest)
+  const vc = decrypted.slice(0, 8)
+  t.ok(equal(vc, VC), 'responder VC verification passed')
+
+  const padCLen = (decrypted[12] << 8) | decrypted[13]
+  const iaLenOffset = 14 + padCLen
+  const iaLen = (decrypted[iaLenOffset] << 8) | decrypted[iaLenOffset + 1]
+  const ia = decrypted.slice(iaLenOffset + 2, iaLenOffset + 2 + iaLen)
+
+  t.ok(ia.length > 0, 'IA payload is non-empty')
+  t.equal(ia[0], 19, 'IA starts with pstrlen=19')
+  t.equal(arr2text(ia.slice(1, 20)), 'BitTorrent protocol', 'IA contains BT handshake protocol')
+  t.equal(arr2hex(ia.slice(28, 48)), infoHash, 'IA contains correct infoHash')
+  t.equal(arr2hex(ia.slice(48, 68)), peerId, 'IA contains correct peerId')
+
+  t.end()
+})
+
+test('PE: method 1 plaintext (peEnabled=1) handshake and message exchange', t => {
+  t.plan(8)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(1)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    t.equal(wireA._encryptionMethod, 1, 'initiator encryption method 1')
+    t.equal(wireB._encryptionMethod, 1, 'responder encryption method 1')
+    t.notOk(wireA._encryptor._isEncrypted, 'initiator data not encrypted')
+    t.notOk(wireB._encryptor._isEncrypted, 'responder data not encrypted')
+    wireA.handshake(infoHash, peerIdA, { dht: false })
+    wireB.handshake(infoHash, peerIdB, { dht: false })
+  })
+
+  let gotHandshake = 0
+  function onHandshake () {
+    gotHandshake++
+    if (gotHandshake < 2) return
+    wireA.keepAlive()
+    wireB.once('keep-alive', () => t.pass('wireB received keep-alive over method 1'))
+    wireB.keepAlive()
+    wireA.once('keep-alive', () => t.pass('wireA received keep-alive over method 1'))
+  }
+  wireA.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'initiator received correct infoHash (method 1)')
+    t.equal(gotPI, peerIdB, 'initiator received correct peerId (method 1)')
+    onHandshake()
+  })
+  wireB.once('handshake', onHandshake)
+})
+
+test('PE: _detectHandshakeOrPe: byte 0x13 + non-BT-protocol goes to PE path (responder)', t => {
+  t.plan(2)
+
+  // tcpIncoming with peEnabled=2 -> handleIncoming() -> _detectHandshakeOrPe
+  const responder = new Wire('tcpIncoming', 2)
+  t.equal(responder._peState, 'idle', 'responder starts idle')
+
+  // First byte = 0x13 (19), remaining 95 bytes = random.
+  // _detectHandshakeOrPe checks the full 20-byte string,
+  // so 'BitTorrent protocol' must NOT match -> PE path.
+  const fakeYa = concat([new Uint8Array([19]), randomBytes(95)])
+  responder._write(fakeYa, () => {
+    // PE path: handleStepB1 + generateStepB2 -> state = 'sentPe2'
+    t.equal(responder._peState, 'sentPe2', 'responder treated data as PE, not handshake')
+  })
+})
+
+test('PE: _detectHandshakeOrPe: byte 0x13 + non-BT-protocol goes to PE path (initiator)', t => {
+  t.plan(3)
+
+  const infoHash = hex()
+  const initiator = new Wire('tcpOutgoing', 2)
+
+  // Step 1: send pe1 (startEncryption throws if !_peEnabled)
+  initiator.startEncryption(infoHash)
+  t.equal(initiator._peState, 'sentPe1', 'initiator sent step1')
+  t.equal(initiator._encryptor.skeyHex, infoHash, 'infoHash set')
+
+  // Fake step2: first byte = 0x13 but NOT "BitTorrent protocol"
+  // Must go to PE path (handleStepA2, not plaintext fallback)
+  const fakeYb = concat([new Uint8Array([19]), randomBytes(95)])
+  initiator._write(fakeYb, () => {
+    // PE path: handleStepA2 computes S, then _advanceEncryption
+    // sends step3 -> state = 'sentPe3'
+    t.equal(initiator._peState, 'sentPe3', 'initiator treated data as step2, not plaintext fallback')
+  })
+})
+
+test('PE: constructor peEnabled accepts 0, 1, 2', t => {
+  t.plan(4)
+
+  t.equal(new Wire('tcpOutgoing', 0)._peEnabled, 0, '0 => 0')
+  t.equal(new Wire('tcpOutgoing', 1)._peEnabled, 1, '1 => 1')
+  t.equal(new Wire('tcpOutgoing', 2)._peEnabled, 2, '2 => 2')
+  t.equal(new Wire('tcpOutgoing')._peEnabled, 0, 'default => 0')
+})
+
+test('PE: outgoing fallback to plaintext when peer sends handshake instead of pe2', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerId = hex()
+
+  fallbackTest(t, 'tcpOutgoing', 1, infoHash, peerId, wire => {
+    wire.once('crypto-handshake', () => t.pass('crypto-handshake emitted on plaintext fallback'))
+  })
+})
+
+test('PE: mixed levels 2->1 — init offers both, responder prefers plaintext -> method 1', t => {
+  t.plan(6)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(2, 1)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    t.equal(wireA._encryptionMethod, 1, 'initiator method 1')
+    t.equal(wireB._encryptionMethod, 1, 'responder method 1')
+    t.notOk(wireA._encryptor._isEncrypted, 'initiator data not encrypted')
+    t.notOk(wireB._encryptor._isEncrypted, 'responder data not encrypted')
+    wireA.handshake(infoHash, peerIdA, { dht: false })
+    wireB.handshake(infoHash, peerIdB, { dht: false })
+  })
+
+  wireA.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'initiator correct infoHash')
+    t.equal(gotPI, peerIdB, 'initiator correct peerId')
+  })
+})
+
+test('PE: mixed levels 1->2 — init offers only plaintext, respondent prefers RC4 -> method 1 forced', t => {
+  t.plan(6)
+
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = piped(1, 2)
+
+  startCrypto(wireA, wireB, infoHash)
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    t.equal(wireA._encryptionMethod, 1, 'initiator method 1')
+    t.equal(wireB._encryptionMethod, 1, 'responder method 1')
+    t.notOk(wireA._encryptor._isEncrypted, 'initiator data not encrypted')
+    t.notOk(wireB._encryptor._isEncrypted, 'responder data not encrypted')
+    wireA.handshake(infoHash, peerIdA, { dht: false })
+    wireB.handshake(infoHash, peerIdB, { dht: false })
+  })
+
+  wireA.once('handshake', (gotIH, gotPI) => {
+    t.equal(gotIH, infoHash, 'initiator correct infoHash')
+    t.equal(gotPI, peerIdB, 'initiator correct peerId')
+  })
+})
+
+test('PE: mixed levels 2->0 — init tries PE, peer sends plaintext handshake -> fallback', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerId = hex()
+
+  fallbackTest(t, 'tcpOutgoing', 2, infoHash, peerId, wire => {
+    wire.once('crypto-handshake', () => t.pass('crypto-handshake emitted on plaintext fallback'))
+  })
+})
+
+test('PE: mixed levels 0->2 — init sends BT handshake, responder detects plaintext -> fallback', t => {
+  t.plan(3)
+
+  const infoHash = hex()
+  const peerId = hex()
+
+  fallbackTest(t, 'tcpIncoming', 2, infoHash, peerId)
+})
+
+test('PE: mixed levels 1->0 — init tries PE, peer sends plaintext handshake -> fallback', t => {
+  t.plan(4)
+
+  const infoHash = hex()
+  const peerId = hex()
+
+  fallbackTest(t, 'tcpOutgoing', 1, infoHash, peerId, wire => {
+    wire.once('crypto-handshake', () => t.pass('crypto-handshake emitted on plaintext fallback'))
+  })
+})
+
+test('PE: mixed levels 0->1 — init sends BT handshake, responder detects plaintext -> fallback', t => {
+  t.plan(3)
+
+  const infoHash = hex()
+  const peerId = hex()
+
+  fallbackTest(t, 'tcpIncoming', 1, infoHash, peerId)
+})


### PR DESCRIPTION
<!-- DO NOT POST LINKS OR REFERENCES TO COPYRIGHTED CONTENT IN YOUR ISSUE. -->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
PE/MSE was very broken since day1, then the v2 rewrites broke them even further by making it async

this package does NOT support async write operations, so everything in _parse needs to happen sync

this was a problem because crypto was async, because of browser compat, this was solved by moving mse to its own file, then excluding it from browser via package.json

the old code was also quite horrific by emitting every pe state to handle by 3rd part libs, which was... dumb, so now it only emits 'crypto-handshake' to wait for  setInfoHash to be called, still not great, but better than 4 events with who knows what order being expected

performance is still horrid, previously it was INSANELY bad, now its just bad, vibe-coded some generic perf script [with oversight], and the old rc4 implementation was like x5-x6 slowdown, re-wrote it a bit, now its just a x3-x4 slowdown, made the entire thing zero-copy for actual data messages [the protocol handshakes and such are copied, but the data is so minimal it has 0 impact]

nodejs also has a native rc4 implmentation, which makes it become a x2-x3 slowdown instead, but Node 17+ (requires `--openssl-legacy-provider`), if available its detected and used, its also exposed via static Wire.nativeRC4 so downstream deps can do `const usePe = opts.usePe ?? Wire.nativeRC4` to auto-enable it only when native accell is available, if this works well i might write an NAPI module for this to bridge the perf gap

breaking constructor args, retries was removed and peEnabled is a number, not a bool, these breaking changes don't matter, since no1 in the world could have possibly used these parameters as simply enabling them crashed or froze the process, broke webtorrent, caused race conditions etc

retries was bad! whoever wrote it assumed that the wire would time out because PE/MSE caused it to, but PE/MSE can't be the cause of a timeout, it always fails almost right away, even when minimal non-PE/MSE data is sent, this disabled PE/MSE on any form of retry

the same checks also only checked for tcp, not tcp and utp

peEnabled is a number, 0 for off, 1 for handshake encryption and 2 for full encryption, previously we only had 2..., a LOT of clients use just 1 since it offers privacy benefits without insane CPU overhead

it might be worth not using node native's rc4 for method 1, as the JS code is actually faster for <64 bytes

tests might still need checks for if _peerCryptoProvide updates correctly on fallbacks, and tests for connecting mixes of levels 0 1 and 2

**Is there anything you'd like reviewers to focus on?**
idk just... stuff, sanity after working on this is low

most likely tests, they were 60% written by AI [with oversight], so it might have issues, looked fine from what i read from the spec

needs REAL WORLD E2E testing

review using https://github.com/webtorrent/bittorrent-protocol/pull/186/changes?w=1&diff=split for ur own sanity

can this be made more readable?