### PR TITLE
fix: don't encrypt caller's buffer in place in _message()

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ class Wire extends Duplex {
    */
   keepAlive () {
     this._debug('keep-alive')
-    this._pushCopy(MESSAGE_KEEP_ALIVE)
+    this._push(MESSAGE_KEEP_ALIVE)
   }
 
   /**
@@ -363,7 +363,7 @@ class Wire extends Duplex {
     if (this.amChoking) return
     this.amChoking = true
     this._debug('choke')
-    this._pushCopy(MESSAGE_CHOKE)
+    this._push(MESSAGE_CHOKE)
 
     if (this.hasFast) {
       // BEP6: If a peer sends a choke, it MUST reject all requests from the peer to whom the choke
@@ -391,7 +391,7 @@ class Wire extends Duplex {
     if (!this.amChoking) return
     this.amChoking = false
     this._debug('unchoke')
-    this._pushCopy(MESSAGE_UNCHOKE)
+    this._push(MESSAGE_UNCHOKE)
   }
 
   /**
@@ -401,7 +401,7 @@ class Wire extends Duplex {
     if (this.amInterested) return
     this.amInterested = true
     this._debug('interested')
-    this._pushCopy(MESSAGE_INTERESTED)
+    this._push(MESSAGE_INTERESTED)
   }
 
   /**
@@ -411,7 +411,7 @@ class Wire extends Duplex {
     if (!this.amInterested) return
     this.amInterested = false
     this._debug('uninterested')
-    this._pushCopy(MESSAGE_UNINTERESTED)
+    this._push(MESSAGE_UNINTERESTED)
   }
 
   /**
@@ -515,7 +515,7 @@ class Wire extends Duplex {
   haveAll () {
     if (!this.hasFast) throw Error('fast extension is disabled')
     this._debug('have-all')
-    this._pushCopy(MESSAGE_HAVE_ALL)
+    this._push(MESSAGE_HAVE_ALL)
   }
 
   /**
@@ -524,7 +524,7 @@ class Wire extends Duplex {
   haveNone () {
     if (!this.hasFast) throw Error('fast extension is disabled')
     this._debug('have-none')
-    this._pushCopy(MESSAGE_HAVE_NONE)
+    this._push(MESSAGE_HAVE_NONE)
   }
 
   /**
@@ -597,10 +597,6 @@ class Wire extends Duplex {
 
     this._push(buffer)
     if (data) this._push(data)
-  }
-
-  _pushCopy (data) {
-    return this._push(new Uint8Array(data))
   }
 
   _push (data) {

--- a/mse.js
+++ b/mse.js
@@ -35,16 +35,18 @@ function createRC4Cipher (key) {
     s[ii] = s[jj]
     s[jj] = tmp
   }
+  // `buf` belongs to the caller, so write to a new buffer like the native cipher does
   return buf => {
+    const out = new Uint8Array(buf.length)
     for (let i = 0; i < buf.length; i++) {
       ii = (ii + 1) & 0xff
       jj = (jj + s[ii]) & 0xff
       const tmp = s[ii]
       s[ii] = s[jj]
       s[jj] = tmp
-      buf[i] ^= s[(s[ii] + s[jj]) & 0xff]
+      out[i] = buf[i] ^ s[(s[ii] + s[jj]) & 0xff]
     }
-    return buf
+    return out
   }
 }
 

--- a/test/mse.js
+++ b/test/mse.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import test from 'tape'
+import BitField from 'bitfield'
 import Wire from '../index.js'
 import { concat, arr2hex, arr2text, hex2arr, randomBytes, equal, text2arr } from 'uint8-util'
 import { MessageStreamEncryptor } from '../mse.js'
@@ -14,6 +15,17 @@ function piped (levelA, levelB = levelA) {
   const wireA = new Wire('tcpOutgoing', levelA)
   const wireB = new Wire('tcpIncoming', levelB)
   wireA.pipe(wireB).pipe(wireA)
+  return { wireA, wireB }
+}
+
+// Like piped(), but copies every chunk in transit the way a real socket does.
+// A direct pipe hands the sender's own buffer to the receiver, whose decrypt
+// XORs any in-place encryption back out before a test can observe it.
+function socketPiped (levelA, levelB = levelA) {
+  const wireA = new Wire('tcpOutgoing', levelA)
+  const wireB = new Wire('tcpIncoming', levelB)
+  wireA.on('data', chunk => wireB.write(new Uint8Array(chunk)))
+  wireB.on('data', chunk => wireA.write(new Uint8Array(chunk)))
   return { wireA, wireB }
 }
 
@@ -252,7 +264,8 @@ test('PE: MessageStreamEncryptor key exchange and encrypt/decrypt', t => {
   initEnc._isEncrypted = true
 
   const plaintext = new Uint8Array([1, 2, 3, 4, 5])
-  const encrypted = respEnc.encrypt(new Uint8Array(plaintext))
+  const encrypted = respEnc.encrypt(plaintext)
+  t.ok(equal(plaintext, new Uint8Array([1, 2, 3, 4, 5])), 'encrypt leaves the caller\'s buffer alone')
   t.notOk(equal(encrypted, plaintext), 'encrypted data differs from plaintext')
   const decrypted2 = initEnc.decrypt(encrypted)
   t.ok(equal(decrypted2, plaintext), 'decrypted data matches original plaintext')
@@ -510,4 +523,88 @@ test('PE: mixed levels 0->1 — init sends BT handshake, responder detects plain
   const peerId = hex()
 
   fallbackTest(t, 'tcpIncoming', 1, infoHash, peerId)
+})
+
+test('PE: sending does not mutate the caller\'s message payloads', t => {
+  t.plan(6)
+
+  // webtorrent passes the torrent's live BitField and a block from the chunk store
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = socketPiped(2)
+
+  const bitfield = new BitField(256)
+  for (const i of [0, 3, 7, 64, 255]) bitfield.set(i, true)
+  const bitfieldBefore = new Uint8Array(bitfield.buffer)
+
+  const block = randomBytes(64)
+  const blockBefore = new Uint8Array(block)
+
+  wireB.once('bitfield', peerPieces => {
+    t.ok(equal(bitfield.buffer, bitfieldBefore), 'sender\'s bitfield buffer is unchanged')
+    t.ok([0, 3, 7, 64, 255].every(i => peerPieces.get(i)), 'peer received the pieces we have')
+    t.notOk([1, 2, 4, 65, 254].some(i => peerPieces.get(i)), 'peer did not receive pieces we lack')
+  })
+
+  wireB.once('piece', (index, offset, buffer) => {
+    t.equal(index, 1, 'peer received correct piece index')
+    t.ok(equal(block, blockBefore), 'sender\'s block buffer is unchanged')
+    t.ok(equal(buffer, blockBefore), 'peer received the correct block')
+  })
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    wireA.handshake(infoHash, peerIdA, { dht: false })
+    wireB.handshake(infoHash, peerIdB, { dht: false })
+  })
+
+  let gotHandshake = 0
+  function onHandshake () {
+    gotHandshake++
+    if (gotHandshake < 2) return
+    wireA.bitfield(bitfield)
+    wireA.piece(1, 0, block)
+  }
+  wireA.once('handshake', onHandshake)
+  wireB.once('handshake', onHandshake)
+
+  startCrypto(wireA, wireB, infoHash)
+})
+
+test('PE: repeated constant messages survive encryption', t => {
+  t.plan(2)
+
+  // MESSAGE_* are module-level singletons, so corrupting one breaks every wire
+  const infoHash = hex()
+  const peerIdA = hex()
+  const peerIdB = hex()
+
+  const { wireA, wireB } = socketPiped(2)
+
+  let keepAlives = 0
+  wireB.on('keep-alive', () => {
+    keepAlives++
+    if (keepAlives === 2) t.pass('peer received both keep-alives')
+  })
+  wireB.once('choke', () => t.pass('peer received choke sent after a keep-alive'))
+
+  onBoth(wireA, wireB, 'crypto-handshake', () => {
+    wireA.handshake(infoHash, peerIdA, { dht: false })
+    wireB.handshake(infoHash, peerIdB, { dht: false })
+  })
+
+  let gotHandshake = 0
+  function onHandshake () {
+    gotHandshake++
+    if (gotHandshake < 2) return
+    wireA.keepAlive()
+    wireA.keepAlive()
+    wireA.unchoke()
+    wireA.choke()
+  }
+  wireA.once('handshake', onHandshake)
+  wireB.once('handshake', onHandshake)
+
+  startCrypto(wireA, wireB, infoHash)
 })


### PR DESCRIPTION
**What is the purpose of this pull request?**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make?**

The JS RC4 fallback now writes to a new buffer instead of XOR-ing the caller's in place, matching the native path (cipher.update() already returns a fresh buffer). That makes _pushCopy() redundant: the MESSAGE_* constants were only copied to protect them from this same in-place encryption, so it's removed and all seven call sites are plain _push(). Unencrypted wires now copy nothing at all; encrypted ones pay one allocation per chunk, costing 6–17% throughput in npm run perf.

Three test assertions, each verified failing with the fallback reverted: a unit check that encrypt leaves its input alone, a wire-level check that sending a BitField and a block doesn't corrupt the sender's buffers, and one covering repeated constant messages to guard the _pushCopy removal. They use a new socketPiped() helper that copies each chunk in transit — with a direct in-process pipe the receiver's decrypt XORs the corruption back out before it can be observed.

**Which issue (if any) does this pull request address?**

Fixes https://github.com/webtorrent/bittorrent-protocol/issues/205: the JS RC4 fallback in mse.js XOR'd the buffer it was handed, and _push() feeds outgoing messages straight to the encryptor, so any caller passing a buffer it doesn't own had that buffer overwritten with ciphertext. That fallback is what runs by default, since nativeRC4 is false on Node 17+ without --openssl-legacy-provider. bitfield() gets the torrent's live BitField from webtorrent and piece() gets the block read from the chunk store, sending either to an encrypted peer scrambled our own copy.

In practice this silently corrupts the torrent's record of which pieces it has: on webtorrent 3.0.16 / Node 22, a 2.2 GB torrent stalled one piece short for hours with 291 of 564 complete pieces flagged "don't have" and the missing piece flagged "have", so it was never requested. It only shows up mid-torrent, since webtorrent sends haveAll()/haveNone() rather than a bitfield at 0% and 100%.


